### PR TITLE
Bad code committed - could not compile Java code - fixed in this commit

### DIFF
--- a/app/src/main/java/com/aerogear/androidshowcase/features/push/presenters/PushPresenter.java
+++ b/app/src/main/java/com/aerogear/androidshowcase/features/push/presenters/PushPresenter.java
@@ -23,17 +23,7 @@ public class PushPresenter extends BasePresenter<PushView> {
 
     public void unregister() {
         PushService pushService = MobileCore.getInstance().getService(PushService.class);
-        pushService.unregisterDevice(new Callback() {
-            @Override
-            public void onSuccess() {
-                view.unregisterSuccess();
-            }
-
-            @Override
-            public void onError(Throwable error) {
-                view.unregisterError(error);
-            }
-        });
+        pushService.unregisterDevice();
     }
 
     public void register() {
@@ -42,17 +32,7 @@ public class PushPresenter extends BasePresenter<PushView> {
         unifiedPushConfig.setCategories(Arrays.asList("Android", "Example"));
 
         PushService pushService = MobileCore.getInstance().getService(PushService.class);
-        pushService.registerDevice(unifiedPushConfig, new Callback() {
-            @Override
-            public void onSuccess() {
-                view.registerSuccess();
-            }
-
-            @Override
-            public void onError(Throwable error) {
-                view.registerError(error);
-            }
-        });
+        pushService.registerDevice();
     }
 
     public void refreshToken() {


### PR DESCRIPTION
The method "unregisterDevice" does not take an input parameter. The original code attempted to pass in (what looks like to me) an anonymous inner class. The fix required the removal of this input from two methods.

After applying this fix locally, I was able to compile the code and deploy the App to an emulator. 