### PR TITLE
Added dependency on the new Security Module

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -67,12 +67,6 @@ dependencies {
     implementation "com.android.support:cardview-v7:$android_support_version"
     implementation "com.android.support:support-v4:$android_support_version"
     implementation "com.android.support.constraint:constraint-layout:1.0.2"
-    implementation 'org.aerogear:android-core:0.1.0-2018-21'
-    implementation 'org.aerogear:android-auth:0.1.0-2018-21'
-    implementation 'org.aerogear:android-push:0.1.0-2018-21'
-//    implementation 'org.aerogear:android-core:0.1.0-SNAPSHOT'
-//    implementation 'org.aerogear:android-auth:0.1.0-SNAPSHOT'
-//    implementation 'org.aerogear:android-push:0.1.0-SNAPSHOT'
     implementation 'com.squareup.okhttp3:okhttp:3.9.0'
     implementation 'com.datatheorem.android.trustkit:trustkit:1.0.1@aar'
     implementation 'com.scottyab:rootbeer-lib:0.0.6'
@@ -88,6 +82,19 @@ dependencies {
     annotationProcessor 'com.google.dagger:dagger-android-processor:2.11'
 
     implementation 'net.zetetic:android-database-sqlcipher:3.5.7@aar'
+
+    releaseImplementation 'org.aerogear:android-core:0.1.0-2018-21'
+    releaseImplementation 'org.aerogear:android-auth:0.1.0-2018-21'
+    releaseImplementation 'org.aerogear:android-push:0.1.0-2018-21'
+
+    debugImplementation 'org.aerogear:android-core:0.1.0-2018-21'
+    debugImplementation 'org.aerogear:android-auth:0.1.0-2018-21'
+    debugImplementation 'org.aerogear:android-push:0.1.0-2018-21'
+
+    localImplementation 'org.aerogear:android-core:0.1.0-SNAPSHOT'
+    localImplementation 'org.aerogear:android-auth:0.1.0-SNAPSHOT'
+    localImplementation 'org.aerogear:android-push:0.1.0-SNAPSHOT'
+    localImplementation 'org.aerogear:android-security:0.1.0-SNAPSHOT'
 
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.mockito:mockito-core:2.10.0'


### PR DESCRIPTION
## Motivation

We moved out the security features from the Auth Module, so we had to update the showcase app to use the new module (Security Module)

JIRA: https://issues.jboss.org/browse/AEROGEAR-2849

## Description

This PR makes the following changes:

1. Adds release dependencies so that, when releasing, only published packages gets referenced (thus avoiding breaking the build by adding not yet published deps)
2. Adds debug dependencies: this are the same as release dependencies, but the debug variant is not published on maven
3. Adds local dependencies: this deps point to snapshot versions so that local developed version of the SDK can be used.

To avoid having to locally publish the SDK package at every build, this config has been made to android Studio

In Android Studio -> Preferences -> Build, Execution, Deployment -> Compiler
added `install` to `Command-line Options`.

This way, at every build, the snapshots in $HOME/.m2/repository are automatically updated.

## Progress

- [x] Add dependency to the Security Module
- [x] Change the deps so that the build works even if the Security package is not published

## Additional Notes

To select wich variant to build, click in the lower left on `Build Variants`: a pane will appear with a combobox allowing to select the variant.