### PR TITLE
remove implementation dependencies for auth and push

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -67,8 +67,6 @@ dependencies {
     implementation "com.android.support:cardview-v7:$android_support_version"
     implementation "com.android.support:support-v4:$android_support_version"
     implementation "com.android.support.constraint:constraint-layout:1.1.0"
-    implementation "org.aerogear:android-auth:0.1.0-2018-21"
-    implementation "org.aerogear:android-push:0.1.0-2018-21"
     implementation "com.google.firebase:firebase-messaging:$firebase_version"
     implementation "com.datatheorem.android.trustkit:trustkit:1.0.1@aar"
     implementation "com.google.code.gson:gson:2.8.4"


### PR DESCRIPTION
## Motivation

App would not build for local variant, kept getting the following error:
`type already present: org.aerogear.mobile.security.AsyncSecurityCheckExecutor$Builder`

## Description

Removed the `implementation` for `auth` and `push` because this overrides the other implementations so the released version was always getting installed no matter what build variant was selected. 

The SDK modules are already specified in the `app/build.gradle` file [here](https://github.com/aerogear/android-showcase-template/blob/master/app/build.gradle#L86-L102) for the different implementations 