### PR TITLE
[WIP] add browser config for auth service

### DIFF
--- a/app/src/main/java/com/aerogear/androidshowcase/di/SecureApplicationModule.java
+++ b/app/src/main/java/com/aerogear/androidshowcase/di/SecureApplicationModule.java
@@ -18,8 +18,11 @@ import com.aerogear.androidshowcase.domain.store.SecureFileNoteStore;
 import com.aerogear.androidshowcase.domain.store.sqlite.SqliteNoteStore;
 import com.aerogear.androidshowcase.features.authentication.providers.KeycloakAuthenticateProviderImpl;
 import com.aerogear.androidshowcase.features.authentication.providers.OpenIDAuthenticationProvider;
+
 import org.aerogear.mobile.auth.AuthService;
+import org.aerogear.mobile.auth.configuration.AuthBrowsers;
 import org.aerogear.mobile.auth.configuration.AuthServiceConfiguration;
+import org.aerogear.mobile.auth.configuration.BrowserConfiguration;
 import org.aerogear.mobile.core.MobileCore;
 import org.aerogear.mobile.security.SecurityService;
 
@@ -114,7 +117,12 @@ public class SecureApplicationModule {
                 .withRedirectUri("com.aerogear.androidshowcase:/callback")
                 .build();
 
-        authService.init(context, authServiceConfig);
+        BrowserConfiguration browserConfiguration = new BrowserConfiguration.BrowserConfigurationBuilder()
+                .blackList()
+                .browser(AuthBrowsers.CHROME_CUSTOM_TAB)
+                .build();
+
+        authService.init(context, authServiceConfig, browserConfiguration);
         return authService;
     }
     // end::authServiceInit[]


### PR DESCRIPTION
## Motivation

JIRA: https://issues.jboss.org/browse/AEROGEAR-2886

## Description

Update showcase app to use the new API for configuring the browser used during authentication.  See this [PR](https://github.com/aerogear/aerogear-android-sdk/pull/243) for the browser config implementation.

## Progress

- [x] Updated showcase app to use browser config
