### PR TITLE
add base config to network config file

### DIFF
--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <network-security-config>
+    <base-config>
+        <trust-anchors>
+            <certificates src="user"/>
+            <certificates src="system"/>
+        </trust-anchors>
+    </base-config>
     <domain-config cleartextTrafficPermitted="false">
         <domain includeSubdomains="true">security.feedhenry.org</domain>
         <pin-set>
@@ -11,12 +17,6 @@
         // Set this to true for production, at least 2 unique pins must be provided above!
         <trustkit-config enforcePinning="true"></trustkit-config>
     </domain-config>
-    <debug-overrides>
-        <trust-anchors>
-            <!-- Additionally trust user added CAs -->
-            <certificates src="user" />
-        </trust-anchors>
-    </debug-overrides>
 </network-security-config>
 
 


### PR DESCRIPTION
## Motivation

Could not establish a secure connection when using release build

## Description

Added in the base config to the network config file and removed the debug-overrides config as it only applies to debug builds.

## Progress

- [x] added in base config
- [x] removed debug-overrides config