### PR TITLE
ensure proguard keeps sqlcipher lib for release build

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -26,3 +26,7 @@
 -dontwarn com.google.errorprone.annotations.*
 -dontwarn okio.**
 -dontwarn org.slf4j.**
+
+-keep class net.sqlcipher.** {
+    *;
+}


### PR DESCRIPTION
## Motivation

JIRA: https://issues.jboss.org/browse/AEROGEAR-3285

We are providing our own SQLite which seems to be used for the note storage stuff but also effects the security bits (it seems). For release builds, the app failed to launch because of errors loading SQLite `net.sqlcipher.database.SQLiteDatabase.a(unavailable:-1)` (see here for [stacktrace](https://gist.github.com/rachael-oregan/d61ae8b93bfb444b2c81b4484b80480e)).

## Description

The reason that SQLite could not be loaded seemed to be an issue with Proguard.  You can see [here](https://github.com/aerogear/android-showcase-template/blob/master/app/build.gradle#L36) the proguard is being used to minify the code base.  So it seems that progaurd was removing that SQLite lib we've provided.

Instructing proguard to `keep` this library in the proguard rules file solved this issue.

## Progress

- [x] add `keep class sqlcipher` to the progaurd rules file 

## Verification

- Check out this branch
- Ensure that the `mobile-services.json` has `push` and `keycloak` services defined (there's an error at the moment when services in `mobile-service.json` aren't defined (@secondsun is working on this issue https://issues.jboss.org/browse/AEROGEAR-3133)
- Chang build variant to `release`
- You'll need to set the `KEYSTORE_PASSWORD` and `KEY_PASSWORD` environment variables that are needed for signing the app. See [here](https://github.com/aerogear/android-showcase-template/blob/master/app/build.gradle#L23).  DM on IRC (`roregan`) or email me (`roregan@redhat.com`) for these credentials.
- Build & Run the app
- Navigate to `Secure Storage` screen. Ensure you can save a note in the `SQLite Database` store type.  Make sure you can edit and delete the note too.
- Navigate to the `Device Trust` screen.  Ensure the screen loads normally and the security checks are correct. Change the status of a security check e.g. device lock and check that the screen has updated.