### PR TITLE
Aerogear 3133 fail gracefully

### DIFF
--- a/app/src/main/java/com/aerogear/androidshowcase/MainActivity.java
+++ b/app/src/main/java/com/aerogear/androidshowcase/MainActivity.java
@@ -4,6 +4,7 @@ import android.app.Fragment;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
+import android.support.annotation.Nullable;
 import android.support.design.widget.NavigationView;
 import android.support.v4.view.GravityCompat;
 import android.support.v4.widget.DrawerLayout;
@@ -11,6 +12,8 @@ import android.support.v7.app.ActionBarDrawerToggle;
 import android.support.v7.widget.Toolbar;
 import android.util.Log;
 import android.view.MenuItem;
+import butterknife.BindView;
+import butterknife.ButterKnife;
 import com.aerogear.androidshowcase.domain.models.Note;
 import com.aerogear.androidshowcase.features.authentication.AuthenticationDetailsFragment;
 import com.aerogear.androidshowcase.features.authentication.AuthenticationFragment;
@@ -20,16 +23,13 @@ import com.aerogear.androidshowcase.features.storage.NotesDetailFragment;
 import com.aerogear.androidshowcase.features.storage.NotesListFragment;
 import com.aerogear.androidshowcase.mvp.components.HttpHelper;
 import com.aerogear.androidshowcase.navigation.Navigator;
-import org.aerogear.mobile.auth.AuthService;
-import org.aerogear.mobile.auth.user.UserPrincipal;
-import org.aerogear.mobile.core.MobileCore;
-import javax.inject.Inject;
-import butterknife.BindView;
-import butterknife.ButterKnife;
 import dagger.android.AndroidInjection;
 import dagger.android.AndroidInjector;
 import dagger.android.DispatchingAndroidInjector;
 import dagger.android.HasFragmentInjector;
+import javax.inject.Inject;
+import org.aerogear.mobile.auth.AuthService;
+import org.aerogear.mobile.auth.user.UserPrincipal;
 
 public class MainActivity extends BaseActivity
         implements NavigationView.OnNavigationItemSelectedListener, AuthenticationFragment.AuthenticationListener, NotesListFragment.NoteListListener, NotesDetailFragment.SaveNoteListener, AuthenticationDetailsFragment.AuthenticationDetailsListener, HasFragmentInjector {
@@ -41,7 +41,7 @@ public class MainActivity extends BaseActivity
     @Inject
     OpenIDAuthenticationProvider authProvider;
 
-    @Inject
+    @Inject @Nullable
     AuthService authService;
 
     @Inject
@@ -154,7 +154,9 @@ public class MainActivity extends BaseActivity
     @Override
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
         if (requestCode == KeycloakAuthenticateProviderImpl.LOGIN_RESULT_CODE) {
-            authService.handleAuthResult(data);
+            //Put a note here that the null check is not how we expect people to use the SDK and link the good usage to the auth screen
+            if (authService != null)
+                authService.handleAuthResult(data);
         }
     }
     // end::onActivityResult[]

--- a/app/src/main/java/com/aerogear/androidshowcase/SecureApplication.java
+++ b/app/src/main/java/com/aerogear/androidshowcase/SecureApplication.java
@@ -45,7 +45,9 @@ public class SecureApplication extends Application implements HasActivityInjecto
             //only thrown during tests, ignore it
         }
 
-        registerDeviceOnUnifiedPushServer();
+        if (MobileCore.getInstance().getServiceConfigurationByType("push") != null ) {
+            registerDeviceOnUnifiedPushServer();
+        }
     }
 
     protected void initInjector() {

--- a/app/src/main/java/com/aerogear/androidshowcase/di/SecureApplicationComponent.java
+++ b/app/src/main/java/com/aerogear/androidshowcase/di/SecureApplicationComponent.java
@@ -7,21 +7,24 @@ import com.aerogear.androidshowcase.domain.crypto.AesCrypto;
 import com.aerogear.androidshowcase.domain.repositories.NoteRepository;
 import com.aerogear.androidshowcase.domain.services.NoteCrudlService;
 import com.aerogear.androidshowcase.features.authentication.providers.OpenIDAuthenticationProvider;
-import javax.inject.Singleton;
 import dagger.BindsInstance;
 import dagger.Component;
 import dagger.android.AndroidInjectionModule;
+import javax.inject.Singleton;
 
 /**
  * Define the dependencies of the app. Used by Dagger2 to build dependency graph.
  */
 @Singleton
-@Component(modules = {AndroidInjectionModule.class, SecureApplicationModule.class, MainActivityModule.class })
+@Component(modules = {AndroidInjectionModule.class, SecureApplicationModule.class,
+    MainActivityModule.class})
 public interface SecureApplicationComponent {
 
     @Component.Builder
     interface Builder {
-        @BindsInstance Builder application(Application application);
+
+        @BindsInstance
+        Builder application(Application application);
 
         SecureApplicationComponent build();
     }
@@ -29,8 +32,12 @@ public interface SecureApplicationComponent {
     void inject(SecureApplication app);
 
     Context context();
+
     AesCrypto provideAesCrypto();
+
     NoteRepository noteRepository();
+
     OpenIDAuthenticationProvider authProvider();
+
     NoteCrudlService provideNoteCrudleService();
 }

--- a/app/src/main/java/com/aerogear/androidshowcase/di/SecureApplicationModule.java
+++ b/app/src/main/java/com/aerogear/androidshowcase/di/SecureApplicationModule.java
@@ -3,6 +3,7 @@ package com.aerogear.androidshowcase.di;
 import android.app.Application;
 import android.content.Context;
 import android.os.Build;
+import android.support.annotation.Nullable;
 import com.aerogear.androidshowcase.domain.crypto.AesCrypto;
 import com.aerogear.androidshowcase.domain.crypto.AndroidMSecureKeyStore;
 import com.aerogear.androidshowcase.domain.crypto.NullAndroidSecureKeyStore;
@@ -107,9 +108,13 @@ public class SecureApplicationModule {
     // end::securityServiceInit[]
 
     // tag::authServiceInit[]
-    @Provides @Singleton
+    @Provides @Singleton @Nullable
     AuthService provideAuthService(Context context) {
-        AuthService authService = MobileCore.getInstance().getService(AuthService.class);
+        MobileCore core = MobileCore.getInstance();
+        if (core.getServiceConfigurationById("keycloak") == null ) {
+            return null;//I don't like null here, but we don't have the ability to have an
+        }
+        AuthService authService = core.getService(AuthService.class);
         AuthServiceConfiguration authServiceConfig = new AuthServiceConfiguration.AuthConfigurationBuilder()
                 .withRedirectUri("com.aerogear.androidshowcase:/callback")
                 .build();

--- a/app/src/main/java/com/aerogear/androidshowcase/di/SecureApplicationModule.java
+++ b/app/src/main/java/com/aerogear/androidshowcase/di/SecureApplicationModule.java
@@ -111,7 +111,7 @@ public class SecureApplicationModule {
     @Provides @Singleton @Nullable
     AuthService provideAuthService(Context context) {
         MobileCore core = MobileCore.getInstance();
-        if (core.getServiceConfigurationById("keycloak") == null ) {
+        if (core.getServiceConfigurationByType("keycloak") == null ) {
             return null;//I don't like null here, but we don't have the ability to have an
         }
         AuthService authService = core.getService(AuthService.class);

--- a/app/src/main/java/com/aerogear/androidshowcase/di/SecureApplicationModule.java
+++ b/app/src/main/java/com/aerogear/androidshowcase/di/SecureApplicationModule.java
@@ -112,7 +112,9 @@ public class SecureApplicationModule {
     AuthService provideAuthService(Context context) {
         MobileCore core = MobileCore.getInstance();
         if (core.getServiceConfigurationByType("keycloak") == null ) {
-            return null;//I don't like null here, but we don't have the ability to have an
+            return null;//We are allowing this to be nullable because keycloak is not guaranteed to
+                        //be configured.  We are not returning an Optional because we can't guarantee
+                        //Optional is available on Android M and L and we don't want to add Guava.
         }
         AuthService authService = core.getService(AuthService.class);
         AuthServiceConfiguration authServiceConfig = new AuthServiceConfiguration.AuthConfigurationBuilder()

--- a/app/src/main/java/com/aerogear/androidshowcase/features/accesscontrol/AccessControlFragment.java
+++ b/app/src/main/java/com/aerogear/androidshowcase/features/accesscontrol/AccessControlFragment.java
@@ -2,6 +2,7 @@ package com.aerogear.androidshowcase.features.accesscontrol;
 
 import android.app.Activity;
 import android.os.Bundle;
+import android.support.annotation.Nullable;
 import android.support.v4.app.Fragment;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -31,7 +32,7 @@ public class AccessControlFragment extends BaseFragment<AccessControlViewPresent
     @Inject
     AccessControlViewPresenter accessControlViewPresenter;
 
-    @Inject
+    @Inject @Nullable
     AuthService authService;
 
     @Inject

--- a/app/src/main/java/com/aerogear/androidshowcase/features/authentication/providers/KeycloakAuthenticateProviderImpl.java
+++ b/app/src/main/java/com/aerogear/androidshowcase/features/authentication/providers/KeycloakAuthenticateProviderImpl.java
@@ -3,6 +3,7 @@ package com.aerogear.androidshowcase.features.authentication.providers;
 import android.app.Activity;
 import android.content.Context;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.util.Log;
 import com.aerogear.androidshowcase.R;
 import org.aerogear.mobile.auth.AuthService;
@@ -26,7 +27,7 @@ public class KeycloakAuthenticateProviderImpl implements OpenIDAuthenticationPro
     @Inject
     Context context;
 
-    @Inject
+    @Inject @Nullable
     AuthService authService;
 
     @Inject

--- a/app/src/main/java/com/aerogear/androidshowcase/features/device/DeviceFragment.java
+++ b/app/src/main/java/com/aerogear/androidshowcase/features/device/DeviceFragment.java
@@ -160,7 +160,7 @@ public class DeviceFragment extends BaseFragment<DevicePresenter, DeviceView> {
             .withSecurityCheck(SecurityCheckType.HAS_ENCRYPTION_ENABLED)
             .withSecurityCheck(SecurityCheckType.ALLOW_BACKUP_DISABLED);
 
-        if (core.getServiceConfigurationById("metrics") != null) {
+        if (core.getServiceConfigurationByType("metrics") != null) {
             builder.withMetricsService(core.getMetricsService());
         }
 

--- a/app/src/main/java/com/aerogear/androidshowcase/features/network/presenters/UploadNotesPresenter.java
+++ b/app/src/main/java/com/aerogear/androidshowcase/features/network/presenters/UploadNotesPresenter.java
@@ -1,6 +1,7 @@
 package com.aerogear.androidshowcase.features.network.presenters;
 
 import android.os.AsyncTask;
+import android.support.annotation.Nullable;
 import android.util.Log;
 import com.aerogear.androidshowcase.R;
 import com.aerogear.androidshowcase.domain.Constants;
@@ -37,7 +38,7 @@ public class UploadNotesPresenter extends BasePresenter<UploadNotesView> {
 
     private UploadNotesTask uploadNotesTask;
 
-    @Inject
+    @Inject @Nullable
     AuthService authService;
 
     @Inject

--- a/app/src/main/java/com/aerogear/androidshowcase/mvp/components/CertPinningHelper.java
+++ b/app/src/main/java/com/aerogear/androidshowcase/mvp/components/CertPinningHelper.java
@@ -1,5 +1,6 @@
 package com.aerogear.androidshowcase.mvp.components;
 
+import android.support.annotation.Nullable;
 import com.datatheorem.android.trustkit.TrustKit;
 import org.aerogear.mobile.auth.AuthService;
 import java.io.IOException;
@@ -20,7 +21,7 @@ import okhttp3.Request;
 
 public class CertPinningHelper {
 
-    @Inject
+    @Inject @Nullable
     AuthService authService;
 
     public CertPinningHelper() {

--- a/app/src/main/java/com/aerogear/androidshowcase/navigation/Navigator.java
+++ b/app/src/main/java/com/aerogear/androidshowcase/navigation/Navigator.java
@@ -3,7 +3,9 @@ package com.aerogear.androidshowcase.navigation;
 import android.app.FragmentManager;
 import android.app.FragmentTransaction;
 import android.content.Context;
+import android.support.annotation.Nullable;
 import android.support.design.widget.Snackbar;
+import android.widget.Toast;
 import com.aerogear.androidshowcase.BaseActivity;
 import com.aerogear.androidshowcase.MainActivity;
 import com.aerogear.androidshowcase.domain.Constants;
@@ -22,6 +24,8 @@ import com.aerogear.androidshowcase.mvp.views.BaseFragment;
 import org.aerogear.mobile.auth.AuthService;
 import org.aerogear.mobile.auth.user.UserPrincipal;
 import javax.inject.Inject;
+import org.aerogear.mobile.core.MobileCore;
+import org.aerogear.mobile.core.configuration.ServiceConfiguration;
 
 /**
  * A class to control the navigation of the app.
@@ -31,7 +35,7 @@ public class Navigator {
     @Inject
     Context context;
 
-    @Inject
+    @Inject @Nullable
     AuthService authService;
 
     @Inject
@@ -47,11 +51,27 @@ public class Navigator {
     public void navigateToAuthenticationView(final BaseActivity activity) {
         AuthenticationFragment authFragment = new AuthenticationFragment();
         UserPrincipal user = authService.currentUser();
+        if (!isConfigured("keycloak")) {
+            showNotConfiguredDialog("keycloak");
+            return;
+        }
         if (user != null) {
             navigateToAuthenticateDetailsView(activity, user);
         } else {
             loadFragment(activity, authFragment, AuthenticationFragment.TAG);
         }
+    }
+
+    private void showNotConfiguredDialog(String keycloak) {
+        Toast.makeText(context, keycloak + " is not in mobile-core.json", Toast.LENGTH_LONG).show();
+    }
+
+    private boolean isConfigured(String serviceId) {
+        MobileCore core = MobileCore.getInstance();
+        ServiceConfiguration configuration = core
+            .getServiceConfigurationById(serviceId);
+
+        return configuration != null;
     }
 
     public void navigateToAuthenticateDetailsView(final BaseActivity activity, final UserPrincipal user) {

--- a/app/src/main/java/com/aerogear/androidshowcase/navigation/Navigator.java
+++ b/app/src/main/java/com/aerogear/androidshowcase/navigation/Navigator.java
@@ -180,7 +180,7 @@ public class Navigator {
     private boolean isConfigured(String serviceId) {
         MobileCore core = MobileCore.getInstance();
         ServiceConfiguration configuration = core
-            .getServiceConfigurationById(serviceId);
+            .getServiceConfigurationByType(serviceId);
 
         return configuration != null;
     }

--- a/app/src/main/java/com/aerogear/androidshowcase/navigation/Navigator.java
+++ b/app/src/main/java/com/aerogear/androidshowcase/navigation/Navigator.java
@@ -49,12 +49,14 @@ public class Navigator {
     }
 
     public void navigateToAuthenticationView(final BaseActivity activity) {
-        AuthenticationFragment authFragment = new AuthenticationFragment();
-        UserPrincipal user = authService.currentUser();
         if (!isConfigured("keycloak")) {
             showNotConfiguredDialog("keycloak");
             return;
         }
+
+        AuthenticationFragment authFragment = new AuthenticationFragment();
+        UserPrincipal user = authService.currentUser();
+
         if (user != null) {
             navigateToAuthenticateDetailsView(activity, user);
         } else {
@@ -62,24 +64,22 @@ public class Navigator {
         }
     }
 
-    private void showNotConfiguredDialog(String keycloak) {
-        Toast.makeText(context, keycloak + " is not in mobile-core.json", Toast.LENGTH_LONG).show();
-    }
-
-    private boolean isConfigured(String serviceId) {
-        MobileCore core = MobileCore.getInstance();
-        ServiceConfiguration configuration = core
-            .getServiceConfigurationById(serviceId);
-
-        return configuration != null;
-    }
-
     public void navigateToAuthenticateDetailsView(final BaseActivity activity, final UserPrincipal user) {
+        if (!isConfigured("keycloak")) {
+            showNotConfiguredDialog("keycloak");
+            return;
+        }
+
         AuthenticationDetailsFragment authDetailsView = AuthenticationDetailsFragment.forIdentityData(user);
         loadFragment(activity, authDetailsView, AuthenticationDetailsFragment.TAG);
     }
 
     public void navigateToAccessControlView(final BaseActivity activity) {
+        if (!isConfigured("keycloak")) {
+            showNotConfiguredDialog("keycloak");
+            return;
+        }
+
         UserPrincipal currentUser = authService.currentUser();
         if (currentUser != null && currentUser.hasRealmRole(Constants.ACCESS_CONTROL_ROLES.ROLE_MOBILE_USER)) {
             AccessControlFragment accessControView = new AccessControlFragment();
@@ -91,11 +91,32 @@ public class Navigator {
     }
 
     public void navigateToStorageView(BaseActivity activity) {
+        if (!isConfigured("notes-service")) {
+            showNotConfiguredDialog("notes-service");
+            return;
+        }
+
+        if (!isConfigured("keycloak")) {
+            showNotConfiguredDialog("keycloak");
+            return;
+        }
+
+
         NotesListFragment notesListView = new NotesListFragment();
         loadFragment(activity, notesListView, NotesListFragment.TAG);
     }
 
     public void navigateToSingleNoteView(BaseActivity activity, Note note) {
+        if (!isConfigured("notes-service")) {
+            showNotConfiguredDialog("notes-service");
+            return;
+        }
+
+        if (!isConfigured("keycloak")) {
+            showNotConfiguredDialog("keycloak");
+            return;
+        }
+
         NotesDetailFragment noteDetails = NotesDetailFragment.forNote(note);
         loadFragment(activity, noteDetails, NotesDetailFragment.TAG);
     }
@@ -106,11 +127,20 @@ public class Navigator {
     }
 
     public void navigateToPushView(MainActivity activity) {
+        if (!isConfigured("push")) {
+            showNotConfiguredDialog("push");
+            return;
+        }
+
         PushFragment pushFragment = new PushFragment();
         loadFragment(activity, pushFragment, PushFragment.TAG);
     }
 
     public void navigateToNetworkView(MainActivity activity) {
+        if (!isConfigured("keycloak")) {
+            showNotConfiguredDialog("keycloak");
+            return;
+        }
 
         UserPrincipal currentUser = authService.currentUser();
         if (currentUser != null && currentUser.hasRealmRole(Constants.ACCESS_CONTROL_ROLES.ROLE_API_ACCESS)) {
@@ -142,6 +172,18 @@ public class Navigator {
         fm.popBackStack();
     }
 
+
+    private void showNotConfiguredDialog(String serviceId) {
+        Toast.makeText(context, serviceId + " is not in mobile-core.json", Toast.LENGTH_LONG).show();
+    }
+
+    private boolean isConfigured(String serviceId) {
+        MobileCore core = MobileCore.getInstance();
+        ServiceConfiguration configuration = core
+            .getServiceConfigurationById(serviceId);
+
+        return configuration != null;
+    }
 
 
 }


### PR DESCRIPTION
## Motivation

This makes the application not crash when mobile services are not configured and has a toast pop up when you try to navigate to a service 

https://issues.jboss.org/browse/AEROGEAR-3133## Description

<!-- The contents of the Pull Request, such as an overview of the changes implemented and impacted areas, additions, removals, etc. -->

## Progress

- [x] Auth Service Won't Crash
- [x] Metrics Service Won't Crash
- [x] Notes Service Won't Crash
- [x] Friendly Toast

## Additional Notes

This is not the finished work with the friendly dialog box, that work is tracked under the jira : https://issues.jboss.org/browse/AEROGEAR-3060