### PR TITLE
Adding Not available dialog

### DIFF
--- a/app/src/main/java/com/aerogear/androidshowcase/navigation/Navigator.java
+++ b/app/src/main/java/com/aerogear/androidshowcase/navigation/Navigator.java
@@ -50,7 +50,7 @@ public class Navigator {
 
     public void navigateToAuthenticationView(final BaseActivity activity) {
         if (!isConfigured("keycloak")) {
-            showNotConfiguredDialog(activity, "keycloak");
+            showNotConfiguredDialog(activity, "identity management");
             return;
         }
 
@@ -66,7 +66,7 @@ public class Navigator {
 
     public void navigateToAuthenticateDetailsView(final BaseActivity activity, final UserPrincipal user) {
         if (!isConfigured("keycloak")) {
-            showNotConfiguredDialog(activity, "keycloak");
+            showNotConfiguredDialog(activity, "identity management");
             return;
         }
 
@@ -76,7 +76,7 @@ public class Navigator {
 
     public void navigateToAccessControlView(final BaseActivity activity) {
         if (!isConfigured("keycloak")) {
-            showNotConfiguredDialog(activity, "keycloak");
+            showNotConfiguredDialog(activity, "identity management");
             return;
         }
 
@@ -92,12 +92,12 @@ public class Navigator {
 
     public void navigateToStorageView(BaseActivity activity) {
         if (!isConfigured("notes-service")) {
-            showNotConfiguredDialog(activity, "notes-service");
+            showNotConfiguredDialog(activity, "notesservice");
             return;
         }
 
         if (!isConfigured("keycloak")) {
-            showNotConfiguredDialog(activity, "keycloak");
+            showNotConfiguredDialog(activity, "identity management");
             return;
         }
 
@@ -108,12 +108,12 @@ public class Navigator {
 
     public void navigateToSingleNoteView(BaseActivity activity, Note note) {
         if (!isConfigured("notes-service")) {
-            showNotConfiguredDialog(activity, "notes-service");
+            showNotConfiguredDialog(activity, "notes service");
             return;
         }
 
         if (!isConfigured("keycloak")) {
-            showNotConfiguredDialog(activity, "keycloak");
+            showNotConfiguredDialog(activity, "identity management");
             return;
         }
 
@@ -138,7 +138,7 @@ public class Navigator {
 
     public void navigateToNetworkView(MainActivity activity) {
         if (!isConfigured("keycloak")) {
-            showNotConfiguredDialog(activity, "keycloak");
+            showNotConfiguredDialog(activity, "identity management");
             return;
         }
 
@@ -173,10 +173,10 @@ public class Navigator {
     }
 
 
-    private void showNotConfiguredDialog(BaseActivity activity, String serviceId) {
-        NotAvailableDialogFragment dialog = NotAvailableDialogFragment.newInstance(serviceId);
+    private void showNotConfiguredDialog(BaseActivity activity, String friendlyServiceName) {
+        NotAvailableDialogFragment dialog = NotAvailableDialogFragment.newInstance(friendlyServiceName);
         android.support.v4.app.FragmentManager fm = activity.getSupportFragmentManager();
-        dialog.show(fm, serviceId);
+        dialog.show(fm, friendlyServiceName);
 
     }
 

--- a/app/src/main/java/com/aerogear/androidshowcase/navigation/Navigator.java
+++ b/app/src/main/java/com/aerogear/androidshowcase/navigation/Navigator.java
@@ -50,7 +50,7 @@ public class Navigator {
 
     public void navigateToAuthenticationView(final BaseActivity activity) {
         if (!isConfigured("keycloak")) {
-            showNotConfiguredDialog("keycloak");
+            showNotConfiguredDialog(activity, "keycloak");
             return;
         }
 
@@ -66,7 +66,7 @@ public class Navigator {
 
     public void navigateToAuthenticateDetailsView(final BaseActivity activity, final UserPrincipal user) {
         if (!isConfigured("keycloak")) {
-            showNotConfiguredDialog("keycloak");
+            showNotConfiguredDialog(activity, "keycloak");
             return;
         }
 
@@ -76,7 +76,7 @@ public class Navigator {
 
     public void navigateToAccessControlView(final BaseActivity activity) {
         if (!isConfigured("keycloak")) {
-            showNotConfiguredDialog("keycloak");
+            showNotConfiguredDialog(activity, "keycloak");
             return;
         }
 
@@ -92,12 +92,12 @@ public class Navigator {
 
     public void navigateToStorageView(BaseActivity activity) {
         if (!isConfigured("notes-service")) {
-            showNotConfiguredDialog("notes-service");
+            showNotConfiguredDialog(activity, "notes-service");
             return;
         }
 
         if (!isConfigured("keycloak")) {
-            showNotConfiguredDialog("keycloak");
+            showNotConfiguredDialog(activity, "keycloak");
             return;
         }
 
@@ -108,12 +108,12 @@ public class Navigator {
 
     public void navigateToSingleNoteView(BaseActivity activity, Note note) {
         if (!isConfigured("notes-service")) {
-            showNotConfiguredDialog("notes-service");
+            showNotConfiguredDialog(activity, "notes-service");
             return;
         }
 
         if (!isConfigured("keycloak")) {
-            showNotConfiguredDialog("keycloak");
+            showNotConfiguredDialog(activity, "keycloak");
             return;
         }
 
@@ -128,7 +128,7 @@ public class Navigator {
 
     public void navigateToPushView(MainActivity activity) {
         if (!isConfigured("push")) {
-            showNotConfiguredDialog("push");
+            showNotConfiguredDialog(activity, "push");
             return;
         }
 
@@ -138,7 +138,7 @@ public class Navigator {
 
     public void navigateToNetworkView(MainActivity activity) {
         if (!isConfigured("keycloak")) {
-            showNotConfiguredDialog("keycloak");
+            showNotConfiguredDialog(activity, "keycloak");
             return;
         }
 
@@ -173,14 +173,24 @@ public class Navigator {
     }
 
 
-    private void showNotConfiguredDialog(String serviceId) {
-        Toast.makeText(context, serviceId + " is not in mobile-core.json", Toast.LENGTH_LONG).show();
+    private void showNotConfiguredDialog(BaseActivity activity, String serviceId) {
+        NotAvailableDialogFragment dialog = NotAvailableDialogFragment.newInstance(serviceId);
+        android.support.v4.app.FragmentManager fm = activity.getSupportFragmentManager();
+        dialog.show(fm, serviceId);
+
     }
 
     private boolean isConfigured(String serviceId) {
         MobileCore core = MobileCore.getInstance();
         ServiceConfiguration configuration = core
             .getServiceConfigurationByType(serviceId);
+
+        //Some services (keycloak, push) are singleton and by type
+        //Custom Service connectors are looked up by id.
+        //So we check both for null.
+        if (configuration == null) {
+            configuration = core.getServiceConfigurationById(serviceId);
+        }
 
         return configuration != null;
     }

--- a/app/src/main/java/com/aerogear/androidshowcase/navigation/Navigator.java
+++ b/app/src/main/java/com/aerogear/androidshowcase/navigation/Navigator.java
@@ -92,7 +92,7 @@ public class Navigator {
 
     public void navigateToStorageView(BaseActivity activity) {
         if (!isConfigured("notes-service")) {
-            showNotConfiguredDialog(activity, "notesservice");
+            showNotConfiguredDialog(activity, "notes service");
             return;
         }
 

--- a/app/src/main/java/com/aerogear/androidshowcase/navigation/NotAvailableDialogFragment.java
+++ b/app/src/main/java/com/aerogear/androidshowcase/navigation/NotAvailableDialogFragment.java
@@ -1,0 +1,74 @@
+package com.aerogear.androidshowcase.navigation;
+
+import android.app.AlertDialog;
+import android.app.Dialog;
+import android.content.DialogInterface;
+import android.os.Bundle;
+import android.support.v4.app.DialogFragment;
+import android.view.LayoutInflater;
+
+import com.aerogear.androidshowcase.R;
+
+/**
+ * This fragment displays the "Feature not available" dialog.
+ */
+public class NotAvailableDialogFragment extends DialogFragment {
+
+    private static final String SERVICE_TYPE_KEY = "serviceType";
+
+
+    private String serviceType;
+
+    public NotAvailableDialogFragment() {
+    }
+
+    /**
+     * Use this factory method to create a new instance of
+     * this fragment using the provided parameters.
+     *
+     * @param serviceType serviceType name to lookup.
+     * @return A new instance of fragment NotAvailableDialogFragment.
+     */
+    // TODO: Rename and change types and number of parameters
+    public static NotAvailableDialogFragment newInstance(String serviceType) {
+        NotAvailableDialogFragment fragment = new NotAvailableDialogFragment();
+        Bundle args = new Bundle();
+        args.putString(SERVICE_TYPE_KEY, serviceType);
+        fragment.setArguments(args);
+        return fragment;
+    }
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        if (getArguments() != null) {
+            this.serviceType = getArguments().getString(SERVICE_TYPE_KEY);
+        }
+    }
+
+    @Override
+    public Dialog onCreateDialog(Bundle savedInstanceState) {
+        // Use the Builder class for convenient dialog construction
+        AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
+        LayoutInflater inflater = getActivity().getLayoutInflater();
+        builder.setCustomTitle(inflater.inflate(R.layout.fragment_not_available_title, null));
+        builder.setMessage(String.format("The service %s does not have a configuration in mobile-services.json.  Refer to the documentation for instructions on how to configure this service.", serviceType))
+                .setPositiveButton(R.string.show_documentation, new DialogInterface.OnClickListener() {
+                    public void onClick(DialogInterface dialog, int id) {
+                        dismiss();
+                    }
+                })
+                .setNegativeButton(R.string.close, new DialogInterface.OnClickListener() {
+                    public void onClick(DialogInterface dialog, int id) {
+                        dismiss();
+                    }
+                });
+        return builder.create();
+    }
+
+    @Override
+    public void onDetach() {
+        super.onDetach();
+    }
+
+}

--- a/app/src/main/res/layout/fragment_not_available_dialog.xml
+++ b/app/src/main/res/layout/fragment_not_available_dialog.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".navigation.NotAvailableDialogFragment">
+
+    <!-- TODO: Update blank fragment layout -->
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:text="@string/hello_blank_fragment" />
+
+</FrameLayout>

--- a/app/src/main/res/layout/fragment_not_available_title.xml
+++ b/app/src/main/res/layout/fragment_not_available_title.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content">
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="8dp"
+        android:text="Feature Not Configured"
+        android:background="@color/colorAccent"
+        android:textColor="@color/white"
+        android:textAlignment="center"
+        android:textAppearance="@android:style/TextAppearance.DeviceDefault"
+        android:textSize="20sp" />
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -118,4 +118,9 @@
     <string name="send_notification">Send notifications from the console</string>
     <string name="fragment_title_push">Push</string>
 
+    <!-- TODO: Remove or change this placeholder text -->
+    <string name="hello_blank_fragment">Hello blank fragment</string>
+    <string name="show_documentation">Show Documentation</string>
+    <string name="close">Close</string>
+
 </resources>


### PR DESCRIPTION
## Motivation

JIRA: https://issues.jboss.org/browse/AEROGEAR-3060

## Description

This displays a dialog for services that are not configured.

## Progress

- [x] Done Task

## Additional Notes

To verify create an empty mobile-services.json file then then try to navigate.  We do not have docs pages in the app yet so the docs button does nothing.

```
{
  "version": 1,
  "clusterName": "https://192.168.37.1:8443",
  "namespace": "myproject",
  "clientId": "app-android",
  "services": [

  ]
}


```