### PR TITLE
fix - missing break on nav

### DIFF
--- a/app/src/main/java/com/aerogear/androidshowcase/MainActivity.java
+++ b/app/src/main/java/com/aerogear/androidshowcase/MainActivity.java
@@ -129,6 +129,7 @@ public class MainActivity extends BaseActivity
                 break;
             case R.id.nav_identity_management_authentication:
                 navigator.navigateToAuthenticationView(this);
+                break;
             case R.id.nav_identity_management_sso:
                 navigator.navigateToUnderConstructorView(this);
                 break;


### PR DESCRIPTION
## Motivation

This small fix adds in a missing `break` that is needed to navigate to out auth page. 