### PR TITLE
Update identity profile screen name

### DIFF
--- a/app/src/main/java/com/aerogear/androidshowcase/MainActivity.java
+++ b/app/src/main/java/com/aerogear/androidshowcase/MainActivity.java
@@ -124,7 +124,7 @@ public class MainActivity extends BaseActivity
                 navigator.navigateToIdentityManagementDocumentation(this, getString(R.string.nav_documentation));
                 break;
             case R.id.nav_identity_management_authentication:
-                navigator.navigateToAuthenticationView(this, getString(R.string.nav_identity_management_authentication));
+                navigator.navigateToAuthenticationView(this, getString(R.string.nav_identity_management_authentication), getString(R.string.nav_identity_management_identity_profile));
                 break;
             case R.id.nav_identity_management_sso:
                 navigator.navigateToSSODocumentation(this, getString(R.string.nav_identity_management_sso));
@@ -190,7 +190,7 @@ public class MainActivity extends BaseActivity
 
     @Override
     public void onAuthSuccess(final UserPrincipal user) {
-        navigator.navigateToAuthenticateDetailsView(this, user, getString(R.string.nav_identity_management_authentication));
+        navigator.navigateToAuthenticateDetailsView(this, user, getString(R.string.nav_identity_management_identity_profile));
     }
 
     @Override
@@ -200,7 +200,7 @@ public class MainActivity extends BaseActivity
 
     @Override
     public void onLogoutSuccess(final UserPrincipal user) {
-        navigator.navigateToAuthenticationView(this, getString(R.string.nav_identity_management_authentication));
+        navigator.navigateToAuthenticationView(this, getString(R.string.nav_identity_management_authentication), getString(R.string.nav_identity_management_identity_profile));
     }
 
     @Override

--- a/app/src/main/java/com/aerogear/androidshowcase/navigation/Navigator.java
+++ b/app/src/main/java/com/aerogear/androidshowcase/navigation/Navigator.java
@@ -51,9 +51,9 @@ public class Navigator {
         loadFragment(activity, homeView, HomeFragment.TAG, title);
     }
 
-    public void navigateToAuthenticationView(final BaseActivity activity, String title) {
+    public void navigateToAuthenticationView(final BaseActivity activity, String authViewTitle, String authDetailsTitle) {
         if (!isConfigured("keycloak")) {
-            showNotConfiguredDialog(activity, "identity management", DocumentUrl.IDENTITY_MANAGEMENT, title);
+            showNotConfiguredDialog(activity, "identity management", DocumentUrl.IDENTITY_MANAGEMENT, authViewTitle);
             return;
         }
 
@@ -61,9 +61,9 @@ public class Navigator {
         UserPrincipal user = authService.currentUser();
 
         if (user != null) {
-            navigateToAuthenticateDetailsView(activity, user, title);
+            navigateToAuthenticateDetailsView(activity, user, authDetailsTitle);
         } else {
-            loadFragment(activity, authFragment, AuthenticationFragment.TAG, title);
+            loadFragment(activity, authFragment, AuthenticationFragment.TAG, authViewTitle);
         }
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -18,6 +18,7 @@
     <!-- Strings related to Identity Management -->
     <string name="fragment_title_authenticate">Identity Management</string>
     <string name="nav_identity_management_authentication">Authentication</string>
+    <string name="nav_identity_management_identity_profile">Identity Profile</string>
     <string name="nav_identity_management_sso">SSO</string>
     <string name="identity_management_landing_title">The Identity Management service allows you to add authentication and authorization to your mobile app.</string>
     <string-array name="identity_management_landing_description">


### PR DESCRIPTION
## Motivation

Currently the identity profile page has the title `Authentication` when it should be `Identity Profile` to match the other showcase apps. See https://docs.google.com/presentation/d/1FZL-Wy5D_wUo5ADrfhpRBh-Ny2rGauI3_C8SBrlk6rw/edit#slide=id.g3c52d834c7_0_65

## Description

Add a second title parameter to `Navigator#navigateToAuthenticationView`  to allow an auth details screen name to be provided.

## Progress

- [x] Done Task

## Screenshots

![screen shot 2018-06-27 at 10 06 13](https://user-images.githubusercontent.com/8698527/41964696-9c6b6e2e-79f2-11e8-8e78-f39fbc5519e4.png)
![screen shot 2018-06-27 at 10 05 54](https://user-images.githubusercontent.com/8698527/41964697-9c8dc668-79f2-11e8-8984-95e406df3598.png)
