### PR TITLE
AEROGEAR-3564 - use #nochrome link to hide navbar on docs

### DIFF
--- a/app/src/main/java/com/aerogear/androidshowcase/features/documentation/DocumentUrl.java
+++ b/app/src/main/java/com/aerogear/androidshowcase/features/documentation/DocumentUrl.java
@@ -4,12 +4,12 @@ package com.aerogear.androidshowcase.features.documentation;
  * This class enumerates the documentation pages we have.
  */
 public enum DocumentUrl {
-    PUSH("https://docs.aerogear.org/aerogear/latest/showcase/push.html"),
-    IDENTITY_MANAGEMENT("https://docs.aerogear.org/aerogear/latest/showcase/idm.html"),
-    DEVICE_SECURITY("https://docs.aerogear.org/aerogear/latest/showcase/device-security.html"),
-    METRICS("https://docs.aerogear.org/aerogear/latest/showcase/metrics.html"),
-    RUNTIME("https://docs.aerogear.org/aerogear/latest/showcase/runtime.html"),
-    IDENTITY_MANAGEMENT_SSO("https://docs.aerogear.org/aerogear/latest/keycloak/index.html?sso=1"),
+    PUSH("https://docs.aerogear.org/aerogear/latest/showcase/push.html#nochrome"),
+    IDENTITY_MANAGEMENT("https://docs.aerogear.org/aerogear/latest/showcase/idm.html#nochrome"),
+    DEVICE_SECURITY("https://docs.aerogear.org/aerogear/latest/showcase/device-security.html#nochrome"),
+    METRICS("https://docs.aerogear.org/aerogear/latest/showcase/metrics.html#nochrome"),
+    RUNTIME("https://docs.aerogear.org/aerogear/latest/showcase/runtime.html#nochrome"),
+    IDENTITY_MANAGEMENT_SSO("https://docs.aerogear.org/aerogear/latest/keycloak/index.html?sso=1#nochrome"),
     NOTES_SERVICE("https://github.com/feedhenry/mobile-security/tree/master/projects/api-server");
 
     private final String url;

--- a/app/src/main/java/com/aerogear/androidshowcase/features/documentation/DocumentUrl.java
+++ b/app/src/main/java/com/aerogear/androidshowcase/features/documentation/DocumentUrl.java
@@ -4,12 +4,12 @@ package com.aerogear.androidshowcase.features.documentation;
  * This class enumerates the documentation pages we have.
  */
 public enum DocumentUrl {
-    PUSH("https://docs.aerogear.org/aerogear/latest/showcase/push.html#nochrome"),
-    IDENTITY_MANAGEMENT("https://docs.aerogear.org/aerogear/latest/showcase/idm.html#nochrome"),
-    DEVICE_SECURITY("https://docs.aerogear.org/aerogear/latest/showcase/device-security.html#nochrome"),
-    METRICS("https://docs.aerogear.org/aerogear/latest/showcase/metrics.html#nochrome"),
-    RUNTIME("https://docs.aerogear.org/aerogear/latest/showcase/runtime.html#nochrome"),
-    IDENTITY_MANAGEMENT_SSO("https://docs.aerogear.org/aerogear/latest/keycloak/index.html?sso=1#nochrome"),
+    PUSH("https://docs.aerogear.org/external/showcase/android/push.html"),
+    IDENTITY_MANAGEMENT("https://docs.aerogear.org/external/showcase/android/idm.html"),
+    DEVICE_SECURITY("https://docs.aerogear.org/external/showcase/android/security.html"),
+    METRICS("https://docs.aerogear.org/external/showcase/android/metrics.html"),
+    RUNTIME("https://docs.aerogear.org/external/showcase/android/runtime.html"),
+    IDENTITY_MANAGEMENT_SSO("https://docs.aerogear.org/external/showcase/android/idmsso.html"),
     NOTES_SERVICE("https://github.com/feedhenry/mobile-security/tree/master/projects/api-server");
 
     private final String url;


### PR DESCRIPTION
## Motivation

<!-- The reason underlying the contents of the PR, can be a link to the originating JIRA -->

JIRA: https://issues.jboss.org/browse/AEROGEAR-3564


waiting for https://github.com/aerogear/antora-ui/pull/13 to be deployed to docs.aerogear.org - change will become visible then (I hope!)

