### PR TITLE
 self signed improvements

### DIFF
--- a/app/src/main/assets/mobile-services.json
+++ b/app/src/main/assets/mobile-services.json
@@ -4,6 +4,6 @@
   "namespace": "myproject",
   "clientId": "app-android",
   "services": [
-      ]
+  ]
 }
 

--- a/app/src/main/java/com/aerogear/androidshowcase/CertificateErrorDialog.java
+++ b/app/src/main/java/com/aerogear/androidshowcase/CertificateErrorDialog.java
@@ -1,0 +1,52 @@
+package com.aerogear.androidshowcase;
+
+import android.app.AlertDialog;
+import android.app.Dialog;
+import android.app.DialogFragment;
+import android.content.DialogInterface;
+import android.os.Bundle;
+import android.support.annotation.Nullable;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+public class CertificateErrorDialog extends DialogFragment {
+
+
+    private Runnable gotoDocs;
+
+    @Nullable
+    @Override
+    public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container, Bundle savedInstanceState) {
+        View view = super.onCreateView(inflater, container, savedInstanceState);
+        getDialog().setCanceledOnTouchOutside(false);
+        return view;
+    }
+
+    @Override
+    public Dialog onCreateDialog(Bundle savedInstanceState) {
+        // Use the Builder class for convenient dialog construction
+        AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
+        builder.setTitle("Certificate Error");
+        builder.setMessage("You may be using self signed certificates that will prevent the showcase from running properly.  Please review the documentation and configure your certificates.")
+                .setPositiveButton("Show Documentation", new DialogInterface.OnClickListener() {
+                    public void onClick(DialogInterface dialog, int id) {
+                        if (gotoDocs != null) {
+                            gotoDocs.run();
+                        } else {
+                            dismiss();
+                        }
+                    }
+                })
+                .setNegativeButton("Close", new DialogInterface.OnClickListener() {
+                    public void onClick(DialogInterface dialog, int id) {
+                        dismiss();
+                    }
+                });
+        return builder.create();
+    }
+
+    public void setGotoDocs(Runnable runnable) {
+        this.gotoDocs = runnable;
+    }
+}

--- a/app/src/main/java/com/aerogear/androidshowcase/MainActivity.java
+++ b/app/src/main/java/com/aerogear/androidshowcase/MainActivity.java
@@ -27,6 +27,9 @@ import com.aerogear.androidshowcase.navigation.Navigator;
 
 import org.aerogear.mobile.auth.AuthService;
 import org.aerogear.mobile.auth.user.UserPrincipal;
+import org.aerogear.mobile.core.executor.AppExecutors;
+import org.aerogear.mobile.core.reactive.Requester;
+import org.aerogear.mobile.core.reactive.Responder;
 
 import javax.inject.Inject;
 
@@ -91,7 +94,7 @@ public class MainActivity extends BaseActivity
 
         // initialise the httphelper
         HttpHelper.init();
-
+        testNetwork();
         // load the main menu fragment
         navigator.navigateToHomeView(this, getString(R.string.fragment_title_home));
     }
@@ -230,6 +233,28 @@ public class MainActivity extends BaseActivity
     @Override
     public void onLogoutError(final Exception error) {
 
+    }
+
+    private void testNetwork() {
+        HttpHelper.checkCertificates(this).respondOn(new AppExecutors().mainThread())
+                .respondWith(new Responder<Boolean>() {
+                    @Override
+                    public void onResult(Boolean value) {
+                        if (!value) {
+                            CertificateErrorDialog dialog = new CertificateErrorDialog();
+                            dialog.setGotoDocs(()-> {
+                                navigator.navigateToSelfSignedCertificateDocumentation(MainActivity.this, "Getting Started");
+                                dialog.dismiss();
+                            });
+                            dialog.show(getFragmentManager(), "CERT_ERROR");
+                        }
+                    }
+
+                    @Override
+                    public void onException(Exception exception) {
+
+                    }
+                });
     }
 
 }

--- a/app/src/main/java/com/aerogear/androidshowcase/SecureApplication.java
+++ b/app/src/main/java/com/aerogear/androidshowcase/SecureApplication.java
@@ -36,9 +36,6 @@ public class SecureApplication extends Application implements HasActivityInjecto
         super.onCreate();
         initInjector();
 
-        // Initialize TrustKit for Certificate Pinning
-        TrustKit.initializeWithNetworkSecurityConfiguration(this, R.xml.network_security_config);
-
         try {
             SQLiteDatabase.loadLibs(this);
         } catch (UnsatisfiedLinkError e) {

--- a/app/src/main/java/com/aerogear/androidshowcase/features/authentication/AuthenticationFragment.java
+++ b/app/src/main/java/com/aerogear/androidshowcase/features/authentication/AuthenticationFragment.java
@@ -21,7 +21,10 @@ import com.aerogear.androidshowcase.mvp.views.BaseFragment;
 import com.aerogear.androidshowcase.navigation.Navigator;
 import org.aerogear.mobile.auth.user.UserPrincipal;
 import org.aerogear.mobile.core.MobileCore;
+import org.aerogear.mobile.core.configuration.MobileCoreJsonParser;
 import org.aerogear.mobile.core.configuration.ServiceConfiguration;
+import org.aerogear.mobile.core.executor.AppExecutors;
+
 import java.io.IOException;
 import javax.inject.Inject;
 import butterknife.BindView;
@@ -78,6 +81,7 @@ public class AuthenticationFragment extends BaseFragment<AuthenticationViewPrese
 
     @Override
     public void onAttach(Activity activity) {
+
         AndroidInjection.inject(this);
         pinningDialog = new ProgressDialog(activity);
         super.onAttach(activity);
@@ -176,8 +180,9 @@ public class AuthenticationFragment extends BaseFragment<AuthenticationViewPrese
             @Override
             public void onFailure(Call call, final IOException e) {
 
-                Snackbar.make(view, e.getMessage(), Snackbar.LENGTH_LONG)
-                        .show();
+                Snackbar snackbar = Snackbar.make(view, e.getMessage(), Snackbar.LENGTH_LONG);
+                snackbar.getView().setBackgroundResource(R.color.white);
+                snackbar.show();
 
                 if (certPinningHelper.checkCertificateVerificationError(e)) {
                     Log.w("Certificate Pinning", "Certificate Pinning Validation Failed", e);
@@ -198,10 +203,13 @@ public class AuthenticationFragment extends BaseFragment<AuthenticationViewPrese
                             logo.setImageResource(R.drawable.ic_lock);
 
                             // Show a warning message to the user
-                            Snackbar.make(view, R.string.insecure_connection_prevent_auth, Snackbar.LENGTH_LONG)
-                                    .show();
+                            Snackbar snackbar = Snackbar.make(view, R.string.insecure_connection_prevent_auth, Snackbar.LENGTH_LONG);
+                            snackbar.getView().setBackgroundResource(R.color.white);
+                            snackbar.show();
                         }
                     });
+                } else {
+                    new AppExecutors().mainThread().submit(()->pinningDialog.hide());
                 }
             }
 

--- a/app/src/main/java/com/aerogear/androidshowcase/features/documentation/DocumentUrl.java
+++ b/app/src/main/java/com/aerogear/androidshowcase/features/documentation/DocumentUrl.java
@@ -10,7 +10,8 @@ public enum DocumentUrl {
     METRICS("https://docs.aerogear.org/aerogear/latest/showcase/metrics.html"),
     RUNTIME("https://docs.aerogear.org/aerogear/latest/showcase/runtime.html"),
     IDENTITY_MANAGEMENT_SSO("https://docs.aerogear.org/aerogear/latest/keycloak/index.html?sso=1"),
-    NOTES_SERVICE("https://github.com/feedhenry/mobile-security/tree/master/projects/api-server");
+    NOTES_SERVICE("https://github.com/feedhenry/mobile-security/tree/master/projects/api-server"),
+    SELF_SIGNED_DOCS("https://docs.aerogear.org/aerogear/latest/getting-started.html#using-self-signed-certificates-in-mobile-apps");
 
     private final String url;
 

--- a/app/src/main/java/com/aerogear/androidshowcase/mvp/components/HttpHelper.java
+++ b/app/src/main/java/com/aerogear/androidshowcase/mvp/components/HttpHelper.java
@@ -1,6 +1,22 @@
 package com.aerogear.androidshowcase.mvp.components;
 
+import android.content.Context;
+
+import org.aerogear.mobile.core.MobileCore;
+import org.aerogear.mobile.core.configuration.MobileCoreConfiguration;
+import org.aerogear.mobile.core.configuration.MobileCoreJsonParser;
+import org.aerogear.mobile.core.configuration.ServiceConfiguration;
+import org.aerogear.mobile.core.http.HttpServiceModule;
+import org.aerogear.mobile.core.reactive.Request;
+import org.aerogear.mobile.core.reactive.Requester;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+
 import okhttp3.OkHttpClient;
+import okhttp3.Response;
 
 /**
  * Created by tjackman on 11/10/17.
@@ -9,13 +25,52 @@ import okhttp3.OkHttpClient;
 public class HttpHelper {
 
     private static OkHttpClient.Builder httpClient;
-
+    private static Boolean CERTIFICATES_CONFIGURED = null;//Start unset
     public HttpHelper() {
 
     }
 
     public static void init() {
         httpClient = new OkHttpClient.Builder();
+    }
+
+    public static Request<Boolean> checkCertificates(Context context) {
+        return Requester.call(() -> {
+            if (CERTIFICATES_CONFIGURED == null) {
+                InputStream jsonStream = context.getAssets().open("mobile-services.json");
+
+                if (jsonStream != null) {
+                    MobileCoreConfiguration configuration = new MobileCoreJsonParser(jsonStream).parse();
+                    Map<String, ServiceConfiguration> configurations = configuration.getServicesConfigPerId();
+
+                    if (configurations.size() != 0) {
+                        HttpServiceModule httpService = MobileCore.getInstance().getHttpLayer();
+                        ServiceConfiguration serviceConfiguration = configurations.values().iterator().next();
+                        String serviceUrl = serviceConfiguration.getUrl();
+                        OkHttpClient client = new OkHttpClient();
+                        okhttp3.Request okHttpRequest = new okhttp3.Request.Builder().url(serviceUrl).get().build();
+                        try {
+                            Response response = client.newCall(okHttpRequest).execute();
+                            response.body().close();
+                            CERTIFICATES_CONFIGURED = true; //Call didn't blow up
+                        } catch (Exception ex) {
+                            CERTIFICATES_CONFIGURED = false;
+                        }
+
+                    } else {
+                        CERTIFICATES_CONFIGURED = true; //No Services to call, so all is OK,
+                    }
+
+                } else {
+                    CERTIFICATES_CONFIGURED = false;
+                }
+
+
+
+            }
+            return CERTIFICATES_CONFIGURED;
+        });
+
     }
 
     public static OkHttpClient.Builder getHttpClient() {

--- a/app/src/main/java/com/aerogear/androidshowcase/mvp/components/HttpHelper.java
+++ b/app/src/main/java/com/aerogear/androidshowcase/mvp/components/HttpHelper.java
@@ -6,6 +6,7 @@ import org.aerogear.mobile.core.MobileCore;
 import org.aerogear.mobile.core.configuration.MobileCoreConfiguration;
 import org.aerogear.mobile.core.configuration.MobileCoreJsonParser;
 import org.aerogear.mobile.core.configuration.ServiceConfiguration;
+import org.aerogear.mobile.core.executor.AppExecutors;
 import org.aerogear.mobile.core.http.HttpServiceModule;
 import org.aerogear.mobile.core.reactive.Request;
 import org.aerogear.mobile.core.reactive.Requester;
@@ -69,7 +70,7 @@ public class HttpHelper {
 
             }
             return CERTIFICATES_CONFIGURED;
-        });
+        }).requestOn(new AppExecutors().networkThread());
 
     }
 

--- a/app/src/main/java/com/aerogear/androidshowcase/mvp/views/BaseAppView.java
+++ b/app/src/main/java/com/aerogear/androidshowcase/mvp/views/BaseAppView.java
@@ -4,6 +4,7 @@ import android.app.Fragment;
 import android.content.Context;
 import android.support.design.widget.Snackbar;
 
+import com.aerogear.androidshowcase.R;
 import com.aerogear.androidshowcase.mvp.components.ProgressDialogHelper;
 
 /**
@@ -38,7 +39,10 @@ public abstract class BaseAppView implements AppView {
     public void showMessage(String message) {
         Context ctx = getContext();
         if (ctx != null) {
-            Snackbar.make(this.fragment.getActivity().getCurrentFocus(), message, Snackbar.LENGTH_SHORT).setAction("Action", null).show();
+            Snackbar snackbar = Snackbar.make(this.fragment.getActivity().getCurrentFocus(), message, Snackbar.LENGTH_SHORT)
+                    .setAction("Action", null);
+            snackbar.getView().setBackgroundResource(R.color.white);
+            snackbar.show();
         }
     }
 

--- a/app/src/main/java/com/aerogear/androidshowcase/navigation/Navigator.java
+++ b/app/src/main/java/com/aerogear/androidshowcase/navigation/Navigator.java
@@ -218,4 +218,8 @@ public class Navigator {
     public void navigateToSSODocumentation(MainActivity mainActivity, String title) {
         gotoDocs(mainActivity, DocumentUrl.IDENTITY_MANAGEMENT_SSO, title);
     }
+
+    public void navigateToSelfSignedCertificateDocumentation(MainActivity mainActivity, String title) {
+        gotoDocs(mainActivity, DocumentUrl.SELF_SIGNED_DOCS, title);
+    }
 }

--- a/readme.adoc
+++ b/readme.adoc
@@ -56,43 +56,6 @@ The Keycloak configuration is saved in the https://github.com/aerogear/android-s
 include::https://raw.githubusercontent.com/aerogear/android-showcase-template/master/app/src/main/assets/mobile-services.json[]
 ....
 
-=== Cert Pinning Configuration
-If you are using HTTPS, update the certificate pinning configuration in link:app/src/main/res/xml/network_security_config.xml[network_security_config.xml] file
-
-To generate the hash value of the certificate, you can use this command:
-[source, bash]
-----
-openssl s_client -servername <hostname> -connect <hostname:port> | openssl x509 -pubkey -noout | openssl pkey -pubin -outform der | openssl dgst -sha256 -binary | openssl enc -base64
-----
-
-If you are using self-signed certificate, follow the instructions in the next section.
-
 == Work with Self-signed Certificate
 
-By default, the app will not work with self-signed certificate due to security reasons. However, to help with local development, you may need to support it.  Here are the steps you can follow:
-
-1. Get the CA certificate of the server. You can use this command:
-+
-[source, bash]
-----
-openssl s_client -showcerts -connect host:port
----- 
-+
-It will print out the full certificate chain of the server and you should save the content of the root certificate into a file.
-
-2. Add the CA certificate to the project. It should be placed in `app/src/main/res/raw`.
-
-3. Update the `network_security_config.xml` file to add the extra trust anchor like this:
-+
-[source, xml]
-----
-<domain-config>
-...
-  <trust-anchors>
-    <certificates src="@raw/ca"/>
-  </trust-anchors>
-...
-</domain-config>
-----        
-+
-The file name should match the name of the CA certificate file.
+By default, the app will not work with self-signed certificate due to security reasons. However, to help with local development, you may need to support it.  link:https://docs.aerogear.org/aerogear/latest/getting-started.html#using-self-signed-certificates-in-mobile-apps[Docs.aerogear.org] has full configuration instructions.


### PR DESCRIPTION
## Motivation
This PR does several things.  First it fixes
 * https://issues.jboss.org/browse/AEROGEAR-3413 (Check that self signed certificates work)
 * https://issues.jboss.org/browse/AEROGEAR-3574 (Dismiss the dialog on Auth screen)

It also makes the following changes 
 * Remove self signed and pinning docs from the readme and link to docs.aerogear.org
 * Removes pinning checks from the app

## Progress

- [x] Remove pinning calls from main activity and authentication screens
- [x] Add Dialog that displays when certificates are not correctly configured
- [update readme]

## Additional Notes

To test this pr configure openshift for the showcase but do NOT configure the self signed certificates.  The app should be navigable and there should be a dialog on the main page which nags that certificates  are not correct.

The app should also work correctly when certificates are imported.